### PR TITLE
Update Connection.php

### DIFF
--- a/src/Frameworks/Laravel/Connection.php
+++ b/src/Frameworks/Laravel/Connection.php
@@ -452,7 +452,7 @@ class Connection extends BaseConnection implements ConnectionInterface
 	 * @param  string  $option
 	 * @return mixed
 	 */
-	public function getConfig($option)
+	public function getConfig($option=null)
 	{
 		return $this->neoeloquent->getConfigOption($option);
 	}


### PR DESCRIPTION
Fixes error 
`
Declaration of Vinelab\NeoEloquent\Frameworks\Laravel\Connection::getConfig($option) should be compatible with Illuminate\Database\Connectio  
  n::getConfig($option = NULL) 
`